### PR TITLE
VCST-2183: Add public store setting PushMessages.Enable

### DIFF
--- a/src/VirtoCommerce.PushMessages.Core/ModuleConstants.cs
+++ b/src/VirtoCommerce.PushMessages.Core/ModuleConstants.cs
@@ -31,6 +31,24 @@ public static class ModuleConstants
     {
         public static class General
         {
+            public static readonly SettingDescriptor Enable = new()
+            {
+                Name = "PushMessages.Enable",
+                GroupName = "Push Messages|General",
+                ValueType = SettingValueType.Boolean,
+                DefaultValue = true,
+                IsPublic = true,
+            };
+
+            public static readonly SettingDescriptor FirebaseCloudMessagingEnable = new()
+            {
+                Name = "PushMessages.FCM.Enable",
+                GroupName = "Push Messages|General",
+                ValueType = SettingValueType.Boolean,
+                DefaultValue = true,
+                IsPublic = true,
+            };
+
             public static SettingDescriptor BatchSize { get; } = new()
             {
                 Name = "PushMessages.BatchSize",
@@ -38,11 +56,12 @@ public static class ModuleConstants
                 ValueType = SettingValueType.Integer,
                 DefaultValue = 50,
             };
-
             public static IEnumerable<SettingDescriptor> AllGeneralSettings
             {
                 get
                 {
+                    yield return Enable;
+                    yield return FirebaseCloudMessagingEnable;
                     yield return BatchSize;
                 }
             }
@@ -91,6 +110,15 @@ public static class ModuleConstants
                     yield return TrackNewRecipientsRecurringJobEnable;
                     yield return TrackNewRecipientsRecurringJobCronExpression;
                 }
+            }
+        }
+
+        public static IEnumerable<SettingDescriptor> StoreSettings
+        {
+            get
+            {
+                yield return General.Enable;
+                yield return General.FirebaseCloudMessagingEnable;
             }
         }
 

--- a/src/VirtoCommerce.PushMessages.Core/ModuleConstants.cs
+++ b/src/VirtoCommerce.PushMessages.Core/ModuleConstants.cs
@@ -31,7 +31,7 @@ public static class ModuleConstants
     {
         public static class General
         {
-            public static readonly SettingDescriptor Enable = new()
+            public static SettingDescriptor Enable { get; } = new()
             {
                 Name = "PushMessages.Enable",
                 GroupName = "Push Messages|General",
@@ -40,7 +40,7 @@ public static class ModuleConstants
                 IsPublic = true,
             };
 
-            public static readonly SettingDescriptor FirebaseCloudMessagingEnable = new()
+            public static SettingDescriptor FirebaseCloudMessagingEnable { get; } = new()
             {
                 Name = "PushMessages.FCM.Enable",
                 GroupName = "Push Messages|General",
@@ -56,12 +56,12 @@ public static class ModuleConstants
                 ValueType = SettingValueType.Integer,
                 DefaultValue = 50,
             };
+
             public static IEnumerable<SettingDescriptor> AllGeneralSettings
             {
                 get
                 {
                     yield return Enable;
-                    yield return FirebaseCloudMessagingEnable;
                     yield return BatchSize;
                 }
             }
@@ -118,7 +118,6 @@ public static class ModuleConstants
             get
             {
                 yield return General.Enable;
-                yield return General.FirebaseCloudMessagingEnable;
             }
         }
 

--- a/src/VirtoCommerce.PushMessages.Data/Extensions/ApplicationBuilderExtensions.cs
+++ b/src/VirtoCommerce.PushMessages.Data/Extensions/ApplicationBuilderExtensions.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
 using FirebaseAdmin;
@@ -10,6 +11,7 @@ using Newtonsoft.Json;
 using VirtoCommerce.Platform.Core.Events;
 using VirtoCommerce.Platform.Core.Settings;
 using VirtoCommerce.Platform.Hangfire;
+using VirtoCommerce.PushMessages.Core;
 using VirtoCommerce.PushMessages.Core.Events;
 using VirtoCommerce.PushMessages.Core.Models;
 using VirtoCommerce.PushMessages.Data.BackgroundJobs;
@@ -62,13 +64,17 @@ public static class ApplicationBuilderExtensions
         settingsRegistrar.RegisterSettingsForType(receiverSettings, "Store");
     }
 
-    private static SettingDescriptor[] ToSettings(this FcmReceiverOptions options)
+    private static IList<SettingDescriptor> ToSettings(this FcmReceiverOptions options)
     {
-        return options
+        var settings = options
             .GetType()
             .GetProperties(BindingFlags.Instance | BindingFlags.Public)
             .Select(x => CreateSetting(x.Name, x.GetValue(options)))
-            .ToArray();
+            .ToList();
+
+        settings.Insert(0, ModuleConstants.Settings.General.FirebaseCloudMessagingEnable);
+
+        return settings;
     }
 
     private static SettingDescriptor CreateSetting(string name, object value)

--- a/src/VirtoCommerce.PushMessages.Web/Localizations/en.PushMessages.json
+++ b/src/VirtoCommerce.PushMessages.Web/Localizations/en.PushMessages.json
@@ -13,7 +13,7 @@
     },
     "PushMessages.FCM.Enable": {
       "title": "Enable firebase cloud messaging (FCM)",
-      "description": "Enable or disable Firebase Cloud Messaging (FCM). Additional configuration is required use following link https://docs.virtocommerce.org/platform/user-guide/push-messages/firebase-cloud-messaging/"
+      "description": "Enable or disable Firebase Cloud Messaging (FCM). Additional configuration is required use following link for configuration https://docs.virtocommerce.org/platform/user-guide/push-messages/firebase-cloud-messaging/"
     },
     "PushMessages.BatchSize": {
       "title": "Batch size",

--- a/src/VirtoCommerce.PushMessages.Web/Localizations/en.PushMessages.json
+++ b/src/VirtoCommerce.PushMessages.Web/Localizations/en.PushMessages.json
@@ -7,6 +7,14 @@
     "PushMessages:delete": "Delete PushMessages related data"
   },
   "settings": {
+    "PushMessages.Enable": {
+      "title": "Enable push notifications",
+      "description": "Enable or disable push notifications"
+    },
+    "PushMessages.FCM.Enable": {
+      "title": "Enable firebase cloud messaging (FCM)",
+      "description": "Enable or disable Firebase Cloud Messaging (FCM). Additional configuration is required use following link https://docs.virtocommerce.org/platform/user-guide/push-messages/firebase-cloud-messaging/"
+    },
     "PushMessages.BatchSize": {
       "title": "Batch size",
       "description": ""

--- a/src/VirtoCommerce.PushMessages.Web/Module.cs
+++ b/src/VirtoCommerce.PushMessages.Web/Module.cs
@@ -28,6 +28,7 @@ using VirtoCommerce.PushMessages.ExperienceApi;
 using VirtoCommerce.PushMessages.ExperienceApi.Authorization;
 using VirtoCommerce.PushMessages.ExperienceApi.Extensions;
 using VirtoCommerce.PushMessages.ExperienceApi.Handlers;
+using VirtoCommerce.StoreModule.Core.Model;
 using VirtoCommerce.Xapi.Core.Extensions;
 using VirtoCommerce.Xapi.Core.Infrastructure;
 
@@ -98,6 +99,9 @@ public class Module : IModule, IHasConfiguration
         // Register settings
         var settingsRegistrar = serviceProvider.GetRequiredService<ISettingsRegistrar>();
         settingsRegistrar.RegisterSettings(ModuleConstants.Settings.AllSettings, ModuleInfo.Id);
+
+        // Register store settings
+        settingsRegistrar.RegisterSettingsForType(ModuleConstants.Settings.StoreSettings, nameof(Store));
 
         // Register permissions
         var permissionsRegistrar = serviceProvider.GetRequiredService<IPermissionsRegistrar>();


### PR DESCRIPTION
## Description
feat: Added PushMessages.Enable public store settings to enable or disable push notifications.
feat: Added PushMessages.FCM.Enable public store settings to enable or disable Firebase Cloud Messaging (FCM). Additional configuration is required use the following link for configuration https://docs.virtocommerce.org/platform/user-guide/push-messages/firebase-cloud-messaging/

![image](https://github.com/user-attachments/assets/c162a095-0880-4933-98a5-1e7c8be1b20f)

![image](https://github.com/user-attachments/assets/69cb2f6e-761c-49ea-976d-dc1b8cdbb0ef)


## References
### QA-test:
### Jira-link:

https://virtocommerce.atlassian.net/browse/VCST-2183
### Artifact URL:
https://vc3prerelease.blob.core.windows.net/packages/VirtoCommerce.PushMessages_3.812.0-pr-9-8693.zip