### PR TITLE
fix(push-messages): prune FCM tokens rejected with terminal errors (VCST-5210)

### DIFF
--- a/src/VirtoCommerce.PushMessages.Data/Handlers/FcmPushMessageRecipientChangedEventHandler.cs
+++ b/src/VirtoCommerce.PushMessages.Data/Handlers/FcmPushMessageRecipientChangedEventHandler.cs
@@ -19,17 +19,20 @@ public class FcmPushMessageRecipientChangedEventHandler : IEventHandler<PushMess
 {
     private readonly IPushMessageService _pushMessageService;
     private readonly IFcmTokenSearchService _fcmTokenSearchService;
+    private readonly IFcmTokenService _fcmTokenService;
     private readonly ISettingsManager _settingsManager;
     private readonly ILogger<FcmPushMessageRecipientChangedEventHandler> _logger;
 
     public FcmPushMessageRecipientChangedEventHandler(
         IPushMessageService pushMessageService,
         IFcmTokenSearchService fcmTokenSearchService,
+        IFcmTokenService fcmTokenService,
         ISettingsManager settingsManager,
         ILogger<FcmPushMessageRecipientChangedEventHandler> logger)
     {
         _pushMessageService = pushMessageService;
         _fcmTokenSearchService = fcmTokenSearchService;
+        _fcmTokenService = fcmTokenService;
         _settingsManager = settingsManager;
         _logger = logger;
     }
@@ -60,31 +63,75 @@ public class FcmPushMessageRecipientChangedEventHandler : IEventHandler<PushMess
 
         await foreach (var searchResult in _fcmTokenSearchService.SearchBatchesNoCloneAsync(searchCriteria))
         {
-            firebaseMessage.Tokens = searchResult.Results.Select(x => x.Token).ToArray();
-            await SendFirebaseMessage(firebaseMessage);
+            var tokens = searchResult.Results;
+            firebaseMessage.Tokens = tokens.Select(x => x.Token).ToArray();
+            await SendFirebaseMessage(firebaseMessage, tokens);
         }
     }
 
-    private async Task SendFirebaseMessage(MulticastMessage firebaseMessage)
+    private async Task SendFirebaseMessage(MulticastMessage firebaseMessage, IList<FcmToken> tokens)
     {
         try
         {
-            var batchResponse = await FirebaseMessaging.DefaultInstance.SendEachForMulticastAsync(firebaseMessage);
+            var responses = await SendEachForMulticastAsync(firebaseMessage);
 
-            if (batchResponse.FailureCount == 0)
+            var staleTokenIds = new List<string>();
+
+            // Responses are returned in the same order as the tokens that were sent,
+            // so response[i] corresponds to tokens[i].
+            for (var i = 0; i < responses.Count && i < tokens.Count; i++)
             {
-                return;
+                var response = responses[i];
+                if (response.IsSuccess)
+                {
+                    continue;
+                }
+
+                _logger.LogError("FCM Send failed: {ErrorCode}", response.ErrorCode);
+
+                if (IsStaleTokenError(response.ErrorCode))
+                {
+                    staleTokenIds.Add(tokens[i].Id);
+                }
             }
 
-            foreach (var response in batchResponse.Responses.Where(x => !x.IsSuccess))
+            if (staleTokenIds.Count > 0)
             {
-                _logger.LogError("FCM Send failed: {Exception}", response.Exception);
+                await _fcmTokenService.DeleteAsync(staleTokenIds);
             }
         }
         catch (Exception ex)
         {
             _logger.LogError("FCM Send failed. {Exception}", ex);
         }
+    }
+
+    /// <summary>
+    /// Per-token terminal errors that mean the registration token is permanently
+    /// invalid and must be pruned so it is not retried on every subsequent push.
+    /// Transient errors (Unavailable, Internal, QuotaExceeded, etc.) are NOT pruned.
+    /// </summary>
+    private static bool IsStaleTokenError(MessagingErrorCode? errorCode)
+    {
+        return errorCode is MessagingErrorCode.Unregistered or MessagingErrorCode.InvalidArgument;
+    }
+
+    /// <summary>
+    /// Seam over the FirebaseAdmin static singleton so the dead-token pruning
+    /// behavior can be unit-tested without constructing the non-public
+    /// <c>BatchResponse</c>/<c>SendResponse</c> types.
+    /// </summary>
+    protected virtual async Task<IList<FcmSendResult>> SendEachForMulticastAsync(MulticastMessage firebaseMessage)
+    {
+        var batchResponse = await FirebaseMessaging.DefaultInstance.SendEachForMulticastAsync(firebaseMessage);
+
+        return batchResponse.Responses
+            .Select(x => new FcmSendResult
+            {
+                IsSuccess = x.IsSuccess,
+                ErrorCode = (x.Exception as FirebaseMessagingException)?.MessagingErrorCode,
+            })
+            .ToArray();
     }
 
     private Task<int> GetBatchSize()

--- a/src/VirtoCommerce.PushMessages.Data/Handlers/FcmSendResult.cs
+++ b/src/VirtoCommerce.PushMessages.Data/Handlers/FcmSendResult.cs
@@ -1,0 +1,17 @@
+using FirebaseAdmin.Messaging;
+
+namespace VirtoCommerce.PushMessages.Data.Handlers;
+
+/// <summary>
+/// Per-token outcome of a Firebase multicast send, aligned by index with the
+/// tokens passed to <see cref="FirebaseMessaging.SendEachForMulticastAsync(MulticastMessage)"/>.
+/// Decouples the dead-token pruning logic from the FirebaseAdmin response types
+/// (<c>BatchResponse</c>/<c>SendResponse</c> have no public constructors), so the
+/// behavior is unit-testable via a seam.
+/// </summary>
+public class FcmSendResult
+{
+    public bool IsSuccess { get; set; }
+
+    public MessagingErrorCode? ErrorCode { get; set; }
+}

--- a/tests/VirtoCommerce.PushMessages.Tests/Fakes.cs
+++ b/tests/VirtoCommerce.PushMessages.Tests/Fakes.cs
@@ -1,0 +1,86 @@
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using VirtoCommerce.Platform.Core.Settings;
+using VirtoCommerce.PushMessages.Core.Models;
+using VirtoCommerce.PushMessages.Core.Services;
+using GeneralSettings = VirtoCommerce.PushMessages.Core.ModuleConstants.Settings.General;
+
+namespace VirtoCommerce.PushMessages.Tests;
+
+/// <summary>Returns a single batch of tokens, then empties so paging terminates.</summary>
+internal sealed class FakeFcmTokenSearchService : IFcmTokenSearchService
+{
+    private readonly IList<FcmToken> _tokens;
+
+    public FakeFcmTokenSearchService(IList<FcmToken> tokens)
+    {
+        _tokens = tokens;
+    }
+
+    public Task<FcmTokenSearchResult> SearchAsync(FcmTokenSearchCriteria criteria, bool clone = true)
+    {
+        return Task.FromResult(new FcmTokenSearchResult
+        {
+            TotalCount = _tokens.Count,
+            Results = _tokens,
+        });
+    }
+}
+
+/// <summary>Records the ids passed to DeleteAsync so the test can assert pruning.</summary>
+internal sealed class RecordingFcmTokenService : IFcmTokenService
+{
+    public List<string> DeletedIds { get; } = new();
+
+    public Task DeleteAsync(IList<string> ids, bool softDelete = false)
+    {
+        DeletedIds.AddRange(ids);
+        return Task.CompletedTask;
+    }
+
+    public Task<IList<FcmToken>> GetAsync(IList<string> ids, string responseGroup = null, bool clone = true)
+    {
+        return Task.FromResult<IList<FcmToken>>(new List<FcmToken>());
+    }
+
+    public Task SaveChangesAsync(IList<FcmToken> models)
+    {
+        return Task.CompletedTask;
+    }
+}
+
+/// <summary>Resolves the BatchSize setting from its descriptor default (50).</summary>
+internal sealed class FakeSettingsManager : ISettingsManager
+{
+    public Task<ObjectSettingEntry> GetObjectSettingAsync(string name, string objectType = null, string objectId = null)
+    {
+        return Task.FromResult(new ObjectSettingEntry(GeneralSettings.BatchSize));
+    }
+
+    public Task<IEnumerable<ObjectSettingEntry>> GetObjectSettingsAsync(IEnumerable<string> names, string objectType = null, string objectId = null)
+    {
+        return Task.FromResult<IEnumerable<ObjectSettingEntry>>(new List<ObjectSettingEntry>());
+    }
+
+    public Task SaveObjectSettingsAsync(IEnumerable<ObjectSettingEntry> objectSettings)
+    {
+        return Task.CompletedTask;
+    }
+
+    public Task RemoveObjectSettingsAsync(IEnumerable<ObjectSettingEntry> objectSettings)
+    {
+        return Task.CompletedTask;
+    }
+
+    // ISettingsRegistrar members — not exercised by these tests.
+    public IEnumerable<SettingDescriptor> AllRegisteredSettings => new List<SettingDescriptor>();
+
+    public void RegisterSettings(IEnumerable<SettingDescriptor> settings, string moduleId = null) { }
+
+    public void RegisterSettingsForType(IEnumerable<SettingDescriptor> settings, string typeName) { }
+
+    public IEnumerable<SettingDescriptor> GetSettingsForType(string typeName) => new List<SettingDescriptor>();
+
+    public IDictionary<string, string[]> GetSettingTypeAssignments() =>
+        new Dictionary<string, string[]>();
+}

--- a/tests/VirtoCommerce.PushMessages.Tests/FcmStaleTokenPruningTests.cs
+++ b/tests/VirtoCommerce.PushMessages.Tests/FcmStaleTokenPruningTests.cs
@@ -1,0 +1,150 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using FirebaseAdmin.Messaging;
+using Microsoft.Extensions.Logging.Abstractions;
+using VirtoCommerce.Platform.Core.Settings;
+using VirtoCommerce.PushMessages.Core.Models;
+using VirtoCommerce.PushMessages.Core.Services;
+using VirtoCommerce.PushMessages.Data.Handlers;
+using Xunit;
+using GeneralSettings = VirtoCommerce.PushMessages.Core.ModuleConstants.Settings.General;
+
+namespace VirtoCommerce.PushMessages.Tests;
+
+/// <summary>
+/// VCST-5210 — when FCM rejects a registration token with a terminal per-token
+/// error (Unregistered / InvalidArgument = HTTP 404, token no longer valid),
+/// the handler must prune that token from storage so it is not retried forever.
+/// Transient errors and successful sends must NOT delete any token.
+/// </summary>
+[Trait("Category", "Unit")]
+public class FcmStaleTokenPruningTests
+{
+    [Fact]
+    public async Task TerminalTokenError_DeletesOffendingToken_VCST5210()
+    {
+        // Arrange: three stored tokens; FCM rejects the middle one as Unregistered (404).
+        var tokens = new[]
+        {
+            new FcmToken { Id = "id-ok", Token = "token-ok", UserId = "u1" },
+            new FcmToken { Id = "id-dead", Token = "token-dead", UserId = "u1" },
+            new FcmToken { Id = "id-also-ok", Token = "token-also-ok", UserId = "u1" },
+        };
+
+        var tokenService = new RecordingFcmTokenService();
+        var handler = new TestableHandler(
+            new FakeFcmTokenSearchService(tokens),
+            tokenService,
+            new FakeSettingsManager(),
+            new[]
+            {
+                new FcmSendResult { IsSuccess = true },
+                new FcmSendResult { IsSuccess = false, ErrorCode = MessagingErrorCode.Unregistered },
+                new FcmSendResult { IsSuccess = true },
+            });
+
+        // Act
+        await handler.SendMessageAsync(NewMessage(), Recipients("u1"));
+
+        // Assert: exactly the dead token's id was deleted.
+        Assert.Single(tokenService.DeletedIds);
+        Assert.Equal("id-dead", tokenService.DeletedIds[0]);
+    }
+
+    [Fact]
+    public async Task InvalidArgumentTokenError_DeletesOffendingToken_VCST5210()
+    {
+        var tokens = new[]
+        {
+            new FcmToken { Id = "id-bad", Token = "token-bad", UserId = "u1" },
+        };
+
+        var tokenService = new RecordingFcmTokenService();
+        var handler = new TestableHandler(
+            new FakeFcmTokenSearchService(tokens),
+            tokenService,
+            new FakeSettingsManager(),
+            new[] { new FcmSendResult { IsSuccess = false, ErrorCode = MessagingErrorCode.InvalidArgument } });
+
+        await handler.SendMessageAsync(NewMessage(), Recipients("u1"));
+
+        Assert.Single(tokenService.DeletedIds);
+        Assert.Equal("id-bad", tokenService.DeletedIds[0]);
+    }
+
+    [Fact]
+    public async Task TransientTokenError_DoesNotDeleteToken_VCST5210()
+    {
+        var tokens = new[]
+        {
+            new FcmToken { Id = "id-transient", Token = "token-transient", UserId = "u1" },
+        };
+
+        var tokenService = new RecordingFcmTokenService();
+        var handler = new TestableHandler(
+            new FakeFcmTokenSearchService(tokens),
+            tokenService,
+            new FakeSettingsManager(),
+            new[] { new FcmSendResult { IsSuccess = false, ErrorCode = MessagingErrorCode.Unavailable } });
+
+        await handler.SendMessageAsync(NewMessage(), Recipients("u1"));
+
+        Assert.Empty(tokenService.DeletedIds);
+    }
+
+    [Fact]
+    public async Task AllTokensSucceed_DeletesNothing_VCST5210()
+    {
+        var tokens = new[]
+        {
+            new FcmToken { Id = "id-1", Token = "token-1", UserId = "u1" },
+            new FcmToken { Id = "id-2", Token = "token-2", UserId = "u1" },
+        };
+
+        var tokenService = new RecordingFcmTokenService();
+        var handler = new TestableHandler(
+            new FakeFcmTokenSearchService(tokens),
+            tokenService,
+            new FakeSettingsManager(),
+            new[]
+            {
+                new FcmSendResult { IsSuccess = true },
+                new FcmSendResult { IsSuccess = true },
+            });
+
+        await handler.SendMessageAsync(NewMessage(), Recipients("u1"));
+
+        Assert.Empty(tokenService.DeletedIds);
+    }
+
+    private static PushMessage NewMessage() => new() { Id = "msg-1", ShortMessage = "hello" };
+
+    private static IList<PushMessageRecipient> Recipients(params string[] userIds) =>
+        userIds.Select(x => new PushMessageRecipient { UserId = x }).ToList();
+
+    /// <summary>
+    /// Overrides the Firebase network seam so the test controls per-token outcomes
+    /// without constructing the non-public FirebaseAdmin response types.
+    /// </summary>
+    private sealed class TestableHandler : FcmPushMessageRecipientChangedEventHandler
+    {
+        private readonly IList<FcmSendResult> _results;
+
+        public TestableHandler(
+            IFcmTokenSearchService fcmTokenSearchService,
+            IFcmTokenService fcmTokenService,
+            ISettingsManager settingsManager,
+            IList<FcmSendResult> results)
+            : base(null, fcmTokenSearchService, fcmTokenService, settingsManager, NullLogger<FcmPushMessageRecipientChangedEventHandler>.Instance)
+        {
+            _results = results;
+        }
+
+        protected override Task<IList<FcmSendResult>> SendEachForMulticastAsync(MulticastMessage firebaseMessage)
+        {
+            return Task.FromResult(_results);
+        }
+    }
+}


### PR DESCRIPTION
## ⚠️ DO NOT MERGE until human review

Opened by the QA auto-fix pipeline. Human review **and** deploy verification are required before merge — do not auto-merge.

## Summary
When a push send to FCM returns a per-token terminal failure (`MessagingErrorCode.Unregistered` / `InvalidArgument` = HTTP 404, the registration token is no longer valid), the module now removes that token from storage so it is not re-queried and re-sent on every subsequent push. Fixes JIRA **[VCST-5210](https://virtocommerce.atlassian.net/browse/VCST-5210)**.

## Root cause
`FcmPushMessageRecipientChangedEventHandler.SendFirebaseMessage` only **logged** each failed `SendResponse` and never inspected its error code or deleted the offending token. A dead token therefore stayed in storage and was re-attempted on every push, producing repeated `fcm.googleapis.com` 404s indefinitely (surfaced by `/qa-monitoring` as a 404 burst with no paired server exception, because failures are caught-and-logged, not re-thrown).

## Fix (minimal, single-repo)
- After a multicast send, walk the per-token responses (FirebaseAdmin returns them in the same order as the tokens sent, so `response[i]` ↔ `tokens[i]`).
- For each failure whose `MessagingErrorCode` is **terminal** (`Unregistered` or `InvalidArgument`), collect the matching token's id and delete it via the **existing** `IFcmTokenService.DeleteAsync` (the same delete path used by `DeleteFcmTokenCommandHandler`).
- **Transient** errors (`Unavailable`, `Internal`, `QuotaExceeded`, etc.) are still logged but **never deleted**, so recoverable tokens are preserved.
- `IFcmTokenService` was already DI-registered in `Module.cs` and is injected into the handler the same way as the two existing transient collaborators — no manifest/DI/contract change.

No public REST/GraphQL/DTO/manifest/schema/migration change; no NuGet add/upgrade.

## Test seam + tests (red → green)
FirebaseAdmin 3.4.0's `BatchResponse`/`SendResponse`/`FirebaseMessagingException` have non-public constructors and cannot be fabricated in a test. To keep the change minimal and testable, the raw static-singleton call was extracted into a single `protected virtual SendEachForMulticastAsync` that returns a small module-owned `FcmSendResult` list (aligned by index). The decision-and-prune logic stays in the production path.

Four new xUnit tests (`FcmStaleTokenPruningTests`, plain `Assert` — the project has no Moq/FluentAssertions) over a subclass that overrides the seam:
- `TerminalTokenError_DeletesOffendingToken_VCST5210` — middle of 3 tokens `Unregistered` → only that token's id deleted.
- `InvalidArgumentTokenError_DeletesOffendingToken_VCST5210` → token deleted.
- `TransientTokenError_DoesNotDeleteToken_VCST5210` — `Unavailable` → nothing deleted.
- `AllTokensSucceed_DeletesNothing_VCST5210` → nothing deleted.

**Red → green proof:** with the prune block disabled, the two delete-asserting tests failed (`Assert.Single() … collection was empty`) while the negative tests stayed green — exactly encoding the bug; restoring the fix turned all green.

## Verification
- [x] `dotnet build -c Debug` (full solution) — Build succeeded, **0 Warning(s) / 0 Error(s)** (clean under `TreatWarningsAsErrors`).
- [x] `dotnet test tests/VirtoCommerce.PushMessages.Tests` — **Passed: 5, Failed: 0, Skipped: 0** (4 new + the pre-existing `Run_Test`).
- All pre-existing tests pass and are **unmodified** (`Test.cs` untouched); only new files added.

## ⚠️ Needs deploy verification
Backend fixes are statically verified only in CI. The live symptom from VCST-5210 (the `fcm.googleapis.com` 404 burst) cannot be reproduced locally — it needs this module built and deployed to QA. Gate 6 closes post-merge via the regression pipeline + `/qa-verify-fix VCST-5210`.

## Reviewer notes
- The handler is registered `AddSingleton` while `IFcmTokenService` is `AddTransient` — a captured-dependency pattern that **already exists** for the two other transient services this singleton injects. Followed the existing convention rather than changing lifetimes (out of minimal-diff scope); flag if the team prefers otherwise.


[VCST-5210]: https://virtocommerce.atlassian.net/browse/VCST-5210?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
Artifact URL:
https://vc3prerelease.blob.core.windows.net/packages/VirtoCommerce.PushMessages_3.1001.0-pr-24-433d.zip