### PR TITLE
VCST-5270: Restore Push Messages bell menu icon (iconUrl 404)

### DIFF
--- a/src/VirtoCommerce.PushMessages.Web/module.manifest
+++ b/src/VirtoCommerce.PushMessages.Web/module.manifest
@@ -17,7 +17,7 @@
     <app id="push-messages">
       <title>Push Messages</title>
       <description>Push Messages</description>
-      <iconUrl>/apps/push-messages/img/icons/logo.svg</iconUrl>
+      <iconUrl>/apps/push-messages/img/icons/safari-pinned-tab.svg</iconUrl>
       <permission>PushMessages:access</permission>
       <supportEmbeddedMode>true</supportEmbeddedMode>
     </app>


### PR DESCRIPTION
## VCST-5270 - Push Messages admin menu icon missing (manifest iconUrl 404)

**DO NOT MERGE until human review.** Opened by `/qa-fix` (QA auto-fix); needs deploy/visual verification.

### Problem
The Admin SPA left-nav **Push Messages** item renders a broken `<img>` - no icon. The manifest's `<app id="push-messages"><iconUrl>` points to `/apps/push-messages/img/icons/logo.svg`, which **404s** (no such file in the build output).

### Root cause
Commit 54729c80 ("feat: Update module logo", pushed directly to `dev` 2026-06-08) repointed the menu `iconUrl` from the working `/apps/push-messages/img/icons/safari-pinned-tab.svg` (the bell) to `/apps/push-messages/img/icons/logo.svg` - a path that does not exist in the built output. That commit also added a new `Content/logo.svg` (a paper-plane icon), but the manifest URL was never wired to where it actually serves, so the menu icon 404s.

### Fix (one line, `src/VirtoCommerce.PushMessages.Web/module.manifest`)
```diff
-      <iconUrl>/apps/push-messages/img/icons/logo.svg</iconUrl>
+      <iconUrl>/apps/push-messages/img/icons/safari-pinned-tab.svg</iconUrl>
```
Restores the previously-working **bell** icon (red/yellow, 196x196), which still exists in the repo and is what the regression environment currently shows.

### Note for the reviewer
This restores the **bell** (the icon prior to 54729c80). If the **paper-plane** redesign added in 54729c80 (`Content/logo.svg`) is the intended direction instead, point `iconUrl` at that asset via the module-content path (the pattern vc-module-news uses: `Modules/$(VirtoCommerce.PushMessages)/Content/logo.svg`) rather than this revert. QA chose to restore the bell.

### Verification (live)
```
404  /apps/push-messages/img/icons/logo.svg             (current dev - broken)
200  /apps/push-messages/img/icons/safari-pinned-tab.svg (this fix - bell)
```
- **Reproduction (Gate 2): trivial-skip** - non-compiled XML manifest value, no behavioral branch, no manifest-asset test harness. Proof is the 404 -> 200 evidence above.
- **Build:** `dotnet build ...Web.csproj` green; no existing tests touched.
- **Needs deploy/visual verification:** icon renders after the alpha artifact deploys to QA.

Generated with [Claude Code](https://claude.com/claude-code)
Jira-link:
https://virtocommerce.atlassian.net/browse/VCST-5270
Artifact URL:
https://vc3prerelease.blob.core.windows.net/packages/VirtoCommerce.PushMessages_3.1003.0-pr-25-7b41.zip