### PR TITLE
VCST-5163: Stable 15 — PushMessages (platform 3.1039.0)

### DIFF
--- a/src/VirtoCommerce.PushMessages.Core/VirtoCommerce.PushMessages.Core.csproj
+++ b/src/VirtoCommerce.PushMessages.Core/VirtoCommerce.PushMessages.Core.csproj
@@ -8,6 +8,6 @@
   </PropertyGroup>
   <ItemGroup>
     
-    <PackageReference Include="VirtoCommerce.Platform.Core" Version="3.1007.10" />
+    <PackageReference Include="VirtoCommerce.Platform.Core" Version="3.1039.0" />
   </ItemGroup>
 </Project>

--- a/src/VirtoCommerce.PushMessages.Data.MySql/VirtoCommerce.PushMessages.Data.MySql.csproj
+++ b/src/VirtoCommerce.PushMessages.Data.MySql/VirtoCommerce.PushMessages.Data.MySql.csproj
@@ -13,7 +13,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="VirtoCommerce.Platform.Data.MySql" Version="3.1007.10" />
+    <PackageReference Include="VirtoCommerce.Platform.Data.MySql" Version="3.1039.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\VirtoCommerce.PushMessages.Data\VirtoCommerce.PushMessages.Data.csproj" />

--- a/src/VirtoCommerce.PushMessages.Data.PostgreSql/VirtoCommerce.PushMessages.Data.PostgreSql.csproj
+++ b/src/VirtoCommerce.PushMessages.Data.PostgreSql/VirtoCommerce.PushMessages.Data.PostgreSql.csproj
@@ -14,7 +14,7 @@
       <IncludeAssets>runtime; build; native; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     
-    <PackageReference Include="VirtoCommerce.Platform.Data.PostgreSql" Version="3.1007.10" />
+    <PackageReference Include="VirtoCommerce.Platform.Data.PostgreSql" Version="3.1039.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\VirtoCommerce.PushMessages.Data\VirtoCommerce.PushMessages.Data.csproj" />

--- a/src/VirtoCommerce.PushMessages.Data.SqlServer/VirtoCommerce.PushMessages.Data.SqlServer.csproj
+++ b/src/VirtoCommerce.PushMessages.Data.SqlServer/VirtoCommerce.PushMessages.Data.SqlServer.csproj
@@ -14,7 +14,7 @@
       <IncludeAssets>runtime; build; native; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     
-    <PackageReference Include="VirtoCommerce.Platform.Data.SqlServer" Version="3.1007.10" />
+    <PackageReference Include="VirtoCommerce.Platform.Data.SqlServer" Version="3.1039.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\VirtoCommerce.PushMessages.Data\VirtoCommerce.PushMessages.Data.csproj" />

--- a/src/VirtoCommerce.PushMessages.Data/VirtoCommerce.PushMessages.Data.csproj
+++ b/src/VirtoCommerce.PushMessages.Data/VirtoCommerce.PushMessages.Data.csproj
@@ -9,9 +9,9 @@
   <ItemGroup>
     <PackageReference Include="FirebaseAdmin" Version="3.4.0" />
     
-    <PackageReference Include="VirtoCommerce.CustomerModule.Core" Version="3.1000.0" />
-    <PackageReference Include="VirtoCommerce.Platform.Data" Version="3.1007.10" />
-    <PackageReference Include="VirtoCommerce.Platform.Hangfire" Version="3.1007.10" />
+    <PackageReference Include="VirtoCommerce.CustomerModule.Core" Version="3.1011.0" />
+    <PackageReference Include="VirtoCommerce.Platform.Data" Version="3.1039.0" />
+    <PackageReference Include="VirtoCommerce.Platform.Hangfire" Version="3.1039.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\VirtoCommerce.PushMessages.Core\VirtoCommerce.PushMessages.Core.csproj" />

--- a/src/VirtoCommerce.PushMessages.ExperienceApi/VirtoCommerce.PushMessages.ExperienceApi.csproj
+++ b/src/VirtoCommerce.PushMessages.ExperienceApi/VirtoCommerce.PushMessages.ExperienceApi.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
   </PropertyGroup>
@@ -8,8 +8,8 @@
     <TypeScriptCompileBlocked>true</TypeScriptCompileBlocked>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="VirtoCommerce.Xapi.Core" Version="3.1000.0" />
-    <PackageReference Include="VirtoCommerce.Platform.Caching" Version="3.1007.10" />
+    <PackageReference Include="VirtoCommerce.Xapi.Core" Version="3.1012.0" />
+    <PackageReference Include="VirtoCommerce.Platform.Caching" Version="3.1039.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\VirtoCommerce.PushMessages.Core\VirtoCommerce.PushMessages.Core.csproj" />

--- a/src/VirtoCommerce.PushMessages.Web/module.manifest
+++ b/src/VirtoCommerce.PushMessages.Web/module.manifest
@@ -4,10 +4,10 @@
   <version>3.1004.0</version>
   <version-tag></version-tag>
 
-  <platformVersion>3.1007.10</platformVersion>
+  <platformVersion>3.1039.0</platformVersion>
   <dependencies>
-    <dependency id="VirtoCommerce.Customer" version="3.1000.0" />
-    <dependency id="VirtoCommerce.Xapi" version="3.1000.0" />
+    <dependency id="VirtoCommerce.Customer" version="3.1011.0" />
+    <dependency id="VirtoCommerce.Xapi" version="3.1012.0" />
   </dependencies>
 
   <title>Push Messages</title>


### PR DESCRIPTION
Part of **Stable 15** (Wave 6). Builds against published platform [3.1039.0](https://github.com/VirtoCommerce/vc-platform/releases/tag/3.1039.0) + Wave 1–5 packages on nuget.org. Version handled by CI.

- deps bumped (Customer 3.1011.0, Xapi 3.1012.0).
- `vc-build Compress` green incl. unit tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dependency-only changes with no application logic edits; risk is limited to compatibility with the new platform and module package versions.
> 
> **Overview**
> **Stable 15 dependency alignment** for the Push Messages module: all Virto Commerce platform packages move from **3.1007.10** to **3.1039.0** across Core, Data (including MySql/PostgreSql/SqlServer), ExperienceApi, and related project references.
> 
> **Module dependencies** in `module.manifest` are updated to match: `platformVersion` **3.1039.0**, **VirtoCommerce.Customer** **3.1011.0** (was 3.1000.0), and **VirtoCommerce.Xapi** **3.1012.0** (was 3.1000.0). NuGet references for `VirtoCommerce.CustomerModule.Core` and `VirtoCommerce.Xapi.Core` follow the same versions. The ExperienceApi project file also drops a BOM on the opening `Project` tag (formatting only).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 53e7f445de4c5ece4dd0469b6ffb8f3ee7cd4330. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
Jira-link:
https://virtocommerce.atlassian.net/browse/VCST-5163
Artifact URL:
https://vc3prerelease.blob.core.windows.net/packages/VirtoCommerce.PushMessages_3.1004.0-pr-26-53e7.zip